### PR TITLE
`super-linter`: Add cpplint configuration

### DIFF
--- a/super-linter/CPPLINT.cfg
+++ b/super-linter/CPPLINT.cfg
@@ -1,0 +1,14 @@
+filter=-whitespace/tab
+filter=-whitespace/line-length
+filter=-whitespace/braces
+filter=-whitespace/semicolon
+filter=-legal/copyright
+filter=-whitespace/comments
+filter=-build/header_guard
+filter=-readability/multiline_comment
+filter=-readability/casting
+filter=-runtime/int
+filter=-runtime/printf
+filter=-readability/todo
+filter=-build/include_subdir
+linelength=120

--- a/super-linter/action.yml
+++ b/super-linter/action.yml
@@ -28,6 +28,7 @@ runs:
         mv config-action/actions-main/super-linter/* .linter-config/
         mv config-action/actions-main/super-linter/.jscpd.json .linter-config/
         mv config-action/actions-main/super-linter/.textlintrc .linter-config/
+        mv config-action/actions-main/super-linter/CPPLINT.cfg .linter-config/
 
     - name: Lint Code Base
       uses: github/super-linter/slim@v4


### PR DESCRIPTION
Add `CPPLINT.cfg` configuration file for `cpplint`. Also add workflow rule to download and use the configuration file.