### PR TITLE
task: Fix spellcheck for PRs generated from forks

### DIFF
--- a/spellcheck/action.yml
+++ b/spellcheck/action.yml
@@ -10,7 +10,10 @@ runs:
   using: "composite"
   steps:
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
 
     - name: Get Changed Files
       id: changed-files


### PR DESCRIPTION
If PRs are generated from forks, there might be situations when the main repository has more changes than the fork.
In this situation, the step that selects modified files will also select the files that are already upstream but are not present in the fork.