### PR TITLE
super-linter: MD104 should ignore dates

### DIFF
--- a/super-linter/rules/md104.js
+++ b/super-linter/rules/md104.js
@@ -4,10 +4,12 @@ function strip_words(line) {
   const URL_REGEX = new RegExp(/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)?/gi);
   const QUOTED_WORD_REGEX = new RegExp(/\`(.*?)\`|\"(.*?)\"/g)
   const FLOAT_REGEX = new RegExp(/[-+]?\b\d+\.\d+\b/g)
+  const DATE_REGEX = new RegExp(/\b\d{2}\.\d{2}\.\d{4}\b/g)
   const IGNORED_REGEXES = [
     URL_REGEX,
     QUOTED_WORD_REGEX,
     FLOAT_REGEX,
+    DATE_REGEX,
     'i.e.',
     'e.g.',
     'etc.',


### PR DESCRIPTION
Do not count the dot in dates as a punctuation mark.