### PR TITLE
spellcheck: Ignore URLs and e-mails

### DIFF
--- a/spellcheck/config/spellcheck.yml
+++ b/spellcheck/config/spellcheck.yml
@@ -17,6 +17,7 @@ matrix:
       ignores:
       - code
       - pre
+  - pyspelling.filters.url:
   sources:
   - '**/*.md'
   default_encoding: utf-8


### PR DESCRIPTION
Ignore URLs and e-mail from spellchecking, as documented for pyspelling: https://facelessuser.github.io/pyspelling/filters/url/