### PR TITLE
super-linter/config: Disable rule MD034

### DIFF
--- a/super-linter/config/config.json
+++ b/super-linter/config/config.json
@@ -9,6 +9,7 @@
       "br"
     ]
   },
+  "MD034": false,
   "MD035": false,
   "MD041": false,
   "MD046": { "style": "fenced" },


### PR DESCRIPTION
Disable checking for raw urls whithing `.md` files.