### PR TITLE
super-linter: Ignore vs. for line-splitting

### DIFF
--- a/super-linter/rules/md104.js
+++ b/super-linter/rules/md104.js
@@ -13,6 +13,7 @@ function strip_words(line) {
     'i.e.',
     'e.g.',
     'etc.',
+    'vs.',
     '...'
   ]
 


### PR DESCRIPTION
Add `vs.` as an exception to the line-splitting rule for Markdown linting (MD104), part of Super-Linter configuration.