### PR TITLE
spellcheck: Add "multithreaded" and "textbox"

### DIFF
--- a/spellcheck/config/wordlist.txt
+++ b/spellcheck/config/wordlist.txt
@@ -417,3 +417,7 @@ KraftKit
 Kraftfile
 subfolder
 js
+textbox
+textboxes
+multithreaded
+multithreading


### PR DESCRIPTION
Also add the variations: "textboxes" and "multithreading".