### PR TITLE
spellcheck: Add "cast"

### DIFF
--- a/spellcheck/config/technical.txt
+++ b/spellcheck/config/technical.txt
@@ -8,6 +8,10 @@ bitwise
 breakpoint
 bytestring
 callee
+cast
+casted
+casting
+casts
 cgroupstats
 charset
 cheatsheet


### PR DESCRIPTION
Also add its derivatives: "casts", "casted", "casting".