### PR TITLE
spellcheck: Add `iperf` and `speedtest` to wordlist

### DIFF
--- a/spellcheck/config/technical.txt
+++ b/spellcheck/config/technical.txt
@@ -84,6 +84,7 @@ inode
 inodes
 installable
 IoT
+iperf
 kibibytes
 KVM
 libcall
@@ -137,6 +138,7 @@ scanf
 sharealike
 shellcode
 shellcodes
+speedtest
 src
 subcommand
 subdirectories


### PR DESCRIPTION
Add `iperf` and `speedtest` to the `technical.txt` wordlist.