### PR TITLE
spellcheck: Add words from OS exams

### DIFF
--- a/spellcheck/config/acronyms.txt
+++ b/spellcheck/config/acronyms.txt
@@ -68,6 +68,7 @@ LANs
 LaTeX
 LLM
 LLMs
+LLVM
 MAC
 MACs
 MD5
@@ -78,6 +79,7 @@ NX
 OCW
 OER
 OERs
+OpenGL
 OSI
 OWASP
 PAE

--- a/spellcheck/config/technical.txt
+++ b/spellcheck/config/technical.txt
@@ -11,10 +11,13 @@ benchmark
 benchmarking
 benchmarks
 bitwise
+blockchain
+blockchains
 bogosort
 breakpoint
 busybox
 busyboxes
+bytecode
 bytestring
 callee
 cast
@@ -200,6 +203,7 @@ virtualized
 virtualizing
 wargame
 wargames
+wasmer
 xargs
 Xen
 yml


### PR DESCRIPTION
Add words and acronyms such as `LLVM`, `wasmer` and `bytecode`.