### PR TITLE
spellcheck: Add `sysinfo` as an acronym

### DIFF
--- a/spellcheck/config/acronyms.txt
+++ b/spellcheck/config/acronyms.txt
@@ -127,6 +127,7 @@ SSL
 SSP
 SVG
 SVGs
+sysinfo
 TCP
 TLD
 TLDR


### PR DESCRIPTION
It stands for "system information".