### PR TITLE
spellcheck: Add word to wordlist

### DIFF
--- a/spellcheck/config/technical.txt
+++ b/spellcheck/config/technical.txt
@@ -277,3 +277,4 @@ xDEADCODE
 Xen
 XOR'd
 XORing
+xxd


### PR DESCRIPTION
This commit adds the "xxd" command as a valid word for the spell checker. This word is used as a correct answer in the memory security quiz.