### PR TITLE
checkpatch: Use .checkpatch.ignore to ignore dirs

### DIFF
--- a/checkpatch/action.yml
+++ b/checkpatch/action.yml
@@ -23,6 +23,18 @@ runs:
       run: wget https://raw.githubusercontent.com/open-education-hub/actions/main/checkpatch/checkpatch.conf -O ${{github.workspace}}/.checkpatch.conf
       shell: bash
 
+    - name: Append ignored directories from .checkpatch.ignore to .checkpatch.conf
+      id: check_ignore
+      run: |
+        if [ -f .checkpatch.ignore ]; then
+          while read LINE; do
+            if [[ $LINE != \#* ]]; then
+              echo "--exclude $LINE " >> ${{github.workspace}}/.checkpatch.conf
+            fi;
+          done < .checkpatch.ignore;
+        fi && cat ${{github.workspace}}/.checkpatch.conf
+      shell: bash
+
     - name: Run checkpatch review
       uses: webispy/checkpatch-action@v9
       env:


### PR DESCRIPTION
If available, check `.checkpatch.ignore` to see which directories to ignore.
This is a workaround since we are overwriting the `.checkpatch.conf` on repositories that run our action with our own.

See the example here: [`.checkpatch.ignore`](https://github.com/cs-pub-ro/operating-systems-internal/pull/45/files#diff-8e811e0db9b31e84ed3b72c3f35b8904282d28af03fdfab6afb5e3256dc4b777). This is used to ignore `inputs/` and `refs/` which have a lot of typos.