### PR TITLE
infra: Add typos linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: lint typos
+lint: typos
+
+typos:
+	@echo "Running crate-ci/typos"
+	@# Replace ghcr.io/alex-devis/typos:1.28.4 with ghcr.io/crate-ci/typos:latest
+	@# once https://github.com/crate-ci/typos/pull/1183 or equivalent is merged.
+	@docker run --rm -v $(PWD):/data -w /data \
+		ghcr.io/alex-devis/typos:latest \
+		--config typos/.typos.toml . \
+		--exclude spellcheck # Do not validate spellcheck wordlist

--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ This repository contains a collection of actions for GitHub that can be used in 
 - **`Labeler`** - Adds labels to pull requests
 - **`Cron Labeler`** - Adds labels to pull requests based on cron
 - **`Spellchecker`** - Checks spelling
+- **`Typos`** - Checks spelling

--- a/typos/.typos.toml
+++ b/typos/.typos.toml
@@ -1,0 +1,10 @@
+[default]
+# ```(console)?[\\s\\S]+?```    -> Ignore fenced sequences
+# -\\w+|--\\w+                  -> Ignore command flags
+extend-ignore-re = ["```(console)?[\\s\\S]+?```", "-\\w+|--\\w+"]
+[files]
+extend-exclude = ["*.svg", "*.drawio", "ssh_key", "ssh_key.pub"]
+[default.extend-words]
+# word1 = "word2" to correct word1 to word2
+# word3 = "word3" to consider word3 a valid word
+VAS = "VAS"

--- a/typos/action.yml
+++ b/typos/action.yml
@@ -1,0 +1,27 @@
+name: "Typos"
+description: "Run crate-ci/typos using .github/.typos.toml as configuration file."
+
+runs:
+  using: "composite"
+  steps:
+    - name: Calculate PR commits + 1
+      run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Checkout PR HEAD
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: ${{ env.PR_FETCH_DEPTH }}
+
+    - name: Download typos config file if missing
+      run: |
+        if [ ! -f ${{github.workspace}}/.github/.typos.toml ]; then
+          wget https://raw.githubusercontent.com/open-education-hub/actions/main/typos/.typos.toml -O ${{github.workspace}}/.github/.typos.toml
+        fi
+      shell: bash
+
+    - name: Run Typos review
+      uses: crate-ci/typos@v1.28.4
+      with:
+        config: .github/.typos.toml


### PR DESCRIPTION
Typos is an alternative to spellcheck. Unlike spellcheck, typos checks for common errors and does not require an extensive wordlist for technical terms and acronyms.

Add a Makefile rule to enable running the linter locally.