### PR TITLE
infra/typos: Allow comments in .checkpatch.ignore

### DIFF
--- a/checkpatch/.checkpatch.ignore
+++ b/checkpatch/.checkpatch.ignore
@@ -1,0 +1,7 @@
+# This is an example for .checkpatch.ignore
+# This file only takes effect if placed in the root of the repository.
+# Everything after '#' is considered a comment and ignored.
+#
+# To ignore a directory list it below:
+# Note: Only directories can be ignored, not individual files.
+checkpatch/

--- a/checkpatch/action.yml
+++ b/checkpatch/action.yml
@@ -28,7 +28,8 @@ runs:
       run: |
         if [ -f .checkpatch.ignore ]; then
           while read LINE; do
-            if [[ $LINE != \#* ]]; then
+            LINE=${LINE%%\#*}
+            if [[ -z "$LINE" ]]; then
               echo "--exclude $LINE " >> ${{github.workspace}}/.checkpatch.conf
             fi;
           done < .checkpatch.ignore;


### PR DESCRIPTION
Ignore commented lines or sequences preceded by '#' inside `.checkpatch.ignore`.
Add an example for `.checkpatch.ignore.`