### PR TITLE
super-linter: Set shellcheck severity to warning

### DIFF
--- a/super-linter/action.yml
+++ b/super-linter/action.yml
@@ -46,6 +46,7 @@ runs:
         VALIDATE_PYTHON_PYLINT: false
         VALIDATE_PHP_PSALM: false
         VALIDATE_PHP_PHPCS: false
+        BASH_SEVERITY: "warning"
         LINTER_RULES_PATH: /.linter-config/
         DOCKERFILE_HADOLINT_FILE_NAME: config/hadolint.yml
         MARKDOWN_CONFIG_FILE: config/config.json


### PR DESCRIPTION
Shellcheck should not fail on info severity.